### PR TITLE
fix decoding nested empty json array error

### DIFF
--- a/trunk/json/json.lua
+++ b/trunk/json/json.lua
@@ -308,7 +308,7 @@ do
 		:link(tt_ignore)             :to " \t\r\n"
 	
 	-- a value, pretty similar to tt_object_value
-	init_token_table (tt_array_seperator) "array ({ or [ or ' or \" or number or boolean or null expected)"
+	init_token_table (tt_array_seperator) "array ({ or [ or ] or ' or \" or number or boolean or null expected)"
 		:link(tt_object_key)         :to "{" 
 		:link(tt_array_seperator)    :to "[" 
 		:link(tt_singlequote_string) :to "'" 
@@ -318,6 +318,7 @@ do
 		:link(tt_boolean)            :to "tf" 
 		:link(tt_null)               :to "n" 
 		:link(tt_ignore)             :to " \t\r\n"
+		:link(tt_array_value)        :to "]"
 	
 	-- valid number tokens
 	init_token_table (tt_numeric) "number"
@@ -470,7 +471,11 @@ do
 			i = i or 1
 			-- loop until ...
 			while true do
-				o[i] = read_value(next_token(tt_array_seperator),tt_array_seperator)
+				local array_token = next_token(tt_array_seperator)
+				if t == tt_array_value then  -- ... we found a terminator token ']' 
+					return o 
+				end
+				o[i] = read_value(array_token, tt_array_seperator)
 				local t = next_token(tt_array_value)
 				if t == tt_comment_start then
 					t = read_comment(tt_array_value)


### PR DESCRIPTION
Empty arrays are currently not handled properly in the parser. I added a test and fix for json.lua.
Please have a look.

Thanks,
Philipp

Ps. json.decode("[]") results in the following error:

lua: ./json.lua:366: Unexpected character at Line 1 character 2: ] (93) when reading array ({ or [ or ' or " or number or boolean or null expected)
Context: 
[]
^
stack traceback:
[C](?): in function 'error'
./json.lua:366: in function 'next_token'
./json.lua:473: in function <./json.lua:468>
(tail call): ?
(tail call): ?
./json.lua:513: in function 'decode'
tests.lua:175: in function 'testJSON4Lua'
tests.lua:222: in main chunk
