### PR TITLE
Modify escaping sequences...

### DIFF
--- a/json4lua/json/json.lua
+++ b/json4lua/json/json.lua
@@ -331,10 +331,7 @@ end
 -- @return The string appropriately escaped.
 function encodeString(s)
   s = string.gsub(s,'\\','\\\\')
-  s = string.gsub(s,'"','\\"')
-  s = string.gsub(s,"'","\\'")
-  s = string.gsub(s,'\n','\\n')
-  s = string.gsub(s,'\t','\\t')
+  s = string.gsub(s,'["/]','\\%1')
   return s 
 end
 


### PR DESCRIPTION
...according to http://www.json.org/ § string. Single quotation character is not in the list and escape it will raise an error in most browser. No need to handle escaped control characters, since you already escape single back slash. Just adding slash character, present the list. 
