### PR TITLE
Configurable pretty-printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ print(json.encode({ 1, 2, 'fred', {first='mars',second='venus',third='earth'} })
 ```json
 [1,2,"fred", {"first":"mars","second":"venus","third","earth"}] 
 ```
+Order of object keys is not guaranteed.
+
+```lua
+json = require('json')
+print(json.encode(
+    { 1, 2, 'fred', {first='mars',second='venus',third='earth'} },
+    { sort_keys=true, pretty=true, indent=4 }))
+```
+```json
+[
+    1,
+    2,
+    "fred",
+    {
+        "first": "mars",
+        "second": "venus",
+        "third": "earth"
+    }
+]
+```
 
 ## Decoding ##
 

--- a/examples/tests.lua
+++ b/examples/tests.lua
@@ -102,6 +102,13 @@ function testJSON4Lua()
   -- NB: This test can fail because of order: need to test further once
   -- decoding is supported.
   -- assert(r==[[{"age":35,"Name":"Craig","email":"craig@lateral.co.za"}]])
+  r = json.encode(s, {sort_keys=true})
+  assert(r==[[{"Name":"Craig","age":35,"email":"craig@lateral.co.za"}]], r)
+  
+  -- Test pretty-printing
+  s = { 2, 'joe', false, nil, 'hi' }
+  r = json.encode(s, { pretty=true, indent=2 })
+  assert(r=='[\n  2,\n  "joe",\n  false,\n  null,\n  "hi"\n]', r)
   
   -- Test decode_scanWhitespace
   if nil then

--- a/examples/timetrials.lua
+++ b/examples/timetrials.lua
@@ -3,7 +3,7 @@
 ]]--
 
 
-require('json')
+json = require('json')
 require('os')
 require('table')
 
@@ -43,4 +43,4 @@ print (jstr)
 --print(type(t1))
 local t2 = os.clock()
 
-print ("Elapsed time=" .. os.difftime(t2,t1) .. "s")
+print ("Elapsed time=" .. (t2 - t1) .. "s")


### PR DESCRIPTION
Pretty-printing features can be enabled with new options parameter.
Supported options are "pretty" (spaces after separators), "indent", and
"sort_keys"; inspired by Python's json.dump options.

Update README and tests for new options.  Fix a mistake in timetrials
and improve its resolution.