### PR TITLE
Fixed syntax error in json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ json = require('json')
 print(json.encode({ 1, 2, 'fred', {first='mars',second='venus',third='earth'} }))
 ```
 ```json
-[1,2,"fred", {"first":"mars","second":"venus","third","earth"}] 
+[1,2,"fred", {"first":"mars","second":"venus","third":"earth"}] 
 ```
 
 ## Decoding ##


### PR DESCRIPTION
In README the syntax of an json example is wrong. I am just fixing it. :D