### PR TITLE
Updating deprecated call resulting in error

### DIFF
--- a/json/json.lua
+++ b/json/json.lua
@@ -235,7 +235,7 @@ function decode_scanNumber(s,startPos)
     endPos = endPos + 1
   end
   local stringValue = 'return ' .. string.sub(s,startPos, endPos-1)
-  local stringEval = loadstring(stringValue)
+  local stringEval = load(stringValue)
   assert(stringEval, 'Failed to scan number [ ' .. stringValue .. '] in JSON string at position ' .. startPos .. ' : ' .. endPos)
   return stringEval(), endPos
 end


### PR DESCRIPTION
From Lua 5.2 reference manual:  Function loadstring is deprecated. Use load instead; it now accepts string arguments and are exactly equivalent to loadstring.