### PR TITLE
Update rpc.lua to include the jsonrpc = "2.0" property

### DIFF
--- a/json/rpc.lua
+++ b/json/rpc.lua
@@ -73,6 +73,7 @@ function json.rpc.call(url, method, ...)
   local JSONRequestArray = {
     id=tostring(math.random()),
     ["method"]=method,
+    ["jsonrpc"]="2.0",
     params = ...
   }
   local httpResponse, result , code


### PR DESCRIPTION
As per the standard in [https://www.jsonrpc.org/specification](https://www.jsonrpc.org/specification) the body of the request should contain a `jsonrpc` property.

This was giving me a hard time in a project and it was because it lacked this property.