### PR TITLE
i think it's a bug

### DIFF
--- a/json/json.lua
+++ b/json/json.lua
@@ -410,6 +410,9 @@ function isArray(t)
       end  -- End of (k~='n')
     end -- End of k,v not an indexed pair
   end  -- End of loop across all pairs
+  if maxIndex ~= #t then
+    return false
+  end
   return true, maxIndex
 end
 


### PR DESCRIPTION
fix:bug ???if a table is a dictionary,like {5000 = 2} there's no necessary inset 4999 "null" and 1 number ! just 1 number